### PR TITLE
Add another documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It installs programs from the command line with a minimal amount of friction.
 - [Discord](https://discord.gg/s9yRQHt)
 - [Gitter](https://gitter.im/lukesampson/scoop)
 - [Documentation](https://scoop.netlify.com/) UNOFFICIAL
-- [Documentation](https://scoop-docs.now.sh/) UNOFFICIAL (with the latest documentation and better app manifest search which differs from the former one)
+- [Documentation](https://scoop-docs.now.sh/) UNOFFICIAL (latest documentation and more features, unlike the former unmaintaind one)
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It installs programs from the command line with a minimal amount of friction.
 - [Discord](https://discord.gg/s9yRQHt)
 - [Gitter](https://gitter.im/lukesampson/scoop)
 - [Documentation](https://scoop.netlify.com/) UNOFFICIAL
+- [Documentation](https://scoop-docs.now.sh/) UNOFFICIAL (with the latest documentation and better app manifest search which differs from the former one)
 
 ## Resources
 


### PR DESCRIPTION
Here's [why I build another documentation site](https://github.com/kidonng/scoop-docs#theres-already-better-documentation-for-scoopsh) in spite of the existing one.